### PR TITLE
Make `Key` public

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Make `Key` public
 - Added a changelog
 - Added SemVer checks to CI
 - Added MSRV checks to CI

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,6 @@
 #![doc=include_str!("../README.md")]
 mod errors;
-pub use errors::{Accumulator, Error, Failure, Result};
+pub use errors::{Accumulator, Error, Failure, Key, Result};
 pub mod synch;
 pub use synch::{Validate, ValidateContext};
 mod wrapper;


### PR DESCRIPTION
Necessary for some downstream convenience methods.